### PR TITLE
feat(galera): add auto-bootstrapping + resilient rejoin; fix entrypoi…

### DIFF
--- a/12-docker-compose.Infra.devDB.yml
+++ b/12-docker-compose.Infra.devDB.yml
@@ -49,8 +49,8 @@ services:
       NODE_ADDRESS: "mariadb_galera1"
       CLUSTER_NAME: "cluster"
       # Pour fonctionnement normal, TOUJOURS liste complète (aucun bootstrap implicite)
-      CLUSTER_SEEDS: ""
-      BOOTSTRAP: "1"
+      CLUSTER_SEEDS: "mariadb_galera1,mariadb_galera2,mariadb_galera3"
+      BOOTSTRAP: "auto"
       SST_USER: "sst_user"
       SST_PASSWORD: "sst_password"
       GCACHE_SIZE: "256M"


### PR DESCRIPTION
[entrypoint]
server/MariaDB/GaleraNode/galera-entrypoint.sh
Implemented auto-bootstrapping logic:
Bootstrap on fresh datadir, or when safe_to_bootstrap=1 and no peers reachable. Otherwise join existing cluster via CLUSTER_SEEDS. Fixed syntax and startup issues:
Proper DEFAULT_ENTRYPOINT detection.
Closed missing fi for GALERA guard.
Render Galera CNF with computed WSREP_CLUSTER_ADDRESS. Added clear logs for bootstrap/join decisions.
[compose]
12-docker-compose.Infra.devDB.yml
Set CLUSTER_SEEDS on all nodes: "mariadb_galera1,mariadb_galera2,mariadb_galera3". Set BOOTSTRAP:
mariadb_galera1: "auto" (first run bootstrap; rejoins afterwards). mariadb_galera2/mariadb_galera3: "0" (join-only).
Healthchecks unchanged; stack now comes up cleanly.